### PR TITLE
SVG loading - Protect against ArrayIndexOutOfBoundsException (-1) as seen in https:…

### DIFF
--- a/src/geomerative/RSVG.java
+++ b/src/geomerative/RSVG.java
@@ -741,7 +741,7 @@ public class RSVG
         switch(charline[i])
           {
           case '-':
-            if(charline[i-1] != 'e' && charline[i-1] != 'E'){
+            if(i>0 && charline[i-1] != 'e' && charline[i-1] != 'E'){
               charline=PApplet.splice(charline,' ',i);
               i++;
             }


### PR DESCRIPTION
…//github.com/rikrd/geomerative/issues/9.

Very simple fix - but I want to let you know that I had to make some other (irrelevant, I think) changes to other parts of the project to get this to compile locally - and that's why I haven't included a fresh geomerative.jar.

There are a few places where you have something like:
```
int smooth = g.smooth;
...
if(smooth > 0){ 
...}
```

Where g is a PGraphics. That would not compile for me (core.jar from processing 2.2.1), I get an error saying that PGraphics.smooth is a boolean ("error: incompatible types: boolean cannot be converted to int").

Changing these instances to a boolean like this:

```
boolean smooth = g.smooth;
...
if(smooth){ 
...}
```

Means it compiles fine.

The source for PGraphics says it's an int (https://github.com/processing/processing/blob/master/core/src/processing/core/PGraphics.java#L176). And your code (treating it as an int) ran fine on my machine.

However, compiling Geomerative using your ant scripts on my installation does not like it.

So I can add those changes to the PR if you like, along with the compiled geomerative.jar... But I'm reluctant to do that because I don't want to break it for everyone except me!

Let me know if you'd like that, or for me to do some more experimenting.

sn